### PR TITLE
Fix bug with 2 dimensional array

### DIFF
--- a/DiceWeb/DiceMVC/Controllers/HomeController.cs
+++ b/DiceWeb/DiceMVC/Controllers/HomeController.cs
@@ -28,16 +28,21 @@ namespace DiceMVC.Controllers
             return View();
         }
         [HttpGet]
-        public IActionResult ShowDices(int count)
+        public IActionResult ShowDices()
         {
-            Game game = new Game();
-            Random generator = new Random();
-            game.Dices = new int[5,2];
-            for (int i=0; i<5; i++)
+            var game = new Game()
+            {
+                Dices = new int[5, 2]
+            };
+
+            var generator = new Random();
+
+            for (int i = 0; i < 5; i++)
             {
                 game.Dices[i, 0] = generator.Next(1, 7);
             }
-            return View(game.Dices);
+
+            return View(game);
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/DiceWeb/DiceMVC/Views/Home/ShowDices.cshtml
+++ b/DiceWeb/DiceMVC/Views/Home/ShowDices.cshtml
@@ -1,5 +1,4 @@
-﻿
-@model System.Int32[,]
+﻿@model Game
 
 @{
     ViewData["Title"] = "ShowDices";
@@ -22,12 +21,10 @@
     <tbody>
         @for (int i =0; i<5;i++)
         {
-           
             {
                 <tr>
                     <td>
-                        @Html.DisplayFor(dice => Model[i,0])
-
+                        @Model.Dices[i,0]
                     </td>
                 </tr>
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44371092/138486596-1751c4c7-edba-4c44-ad27-7882b8689258.png)

@Html.DisplayFor can be used only with field access, property access, single-dimension array index, or single-parameter custom indexer expressions, so you can't use it in your example.

 A better option is to return a game model other than a 2-dimensional int array because you can easily extend the model with new properties in the future without major code changes.